### PR TITLE
Fix palette on new installations

### DIFF
--- a/SEUploader/FrontEnd/Palettes/SEUploader.nb
+++ b/SEUploader/FrontEnd/Palettes/SEUploader.nb
@@ -524,6 +524,7 @@ copied to the clipboard.", Bold],
 WindowSize->All,
 WindowElements->{},
 WindowTitle->"SE Uploader",
+TaggingRules -> {"ImageUploadHistory" -> {}},
 StyleDefinitions->"Palette.nb"
 ]
 (* End of Notebook Content *)


### PR DESCRIPTION
On computers where the palette has never been used, it would fail with a PrependTo::normal message.
